### PR TITLE
release Flutter SDK 1.1.0

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,6 +10,8 @@
   <component name="ChangeListManager">
     <list default="true" id="41faf354-5556-441b-b072-c5715dd28d1d" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CHANGELOG.md" beforeDir="false" afterPath="$PROJECT_DIR$/CHANGELOG.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/example/pubspec.lock" beforeDir="false" afterPath="$PROJECT_DIR$/example/pubspec.lock" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pubspec.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/pubspec.yaml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.0
 
 * Migrate to Android V2
-* upgrade Flutter SDK version for versions < 4.0.0
+* Upgrade Flutter SDK version for versions < 4.0.0
 * Upgrade Kotlin version to 1.6.10
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to 32
 * Upgrade DataDome SDK Core versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+* Migrate to Android V2
+* upgrade Flutter SDK version for versions < 4.0.0
+* Upgrade kotlin version to 1.6.10
+* Upgrade CompileSdkVersion and targetSdkVersion to 32
+* Upgrade DataDome SDK Core versions
+
 ## 1.0.5
 
 * Support null safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Migrate to Android V2
 * upgrade Flutter SDK version for versions < 4.0.0
-* Upgrade kotlin version to 1.6.10
+* Upgrade Kotlin version to 1.6.10
 * Upgrade CompileSdkVersion and targetSdkVersion to 32
 * Upgrade DataDome SDK Core versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Migrate to Android V2
 * upgrade Flutter SDK version for versions < 4.0.0
 * Upgrade Kotlin version to 1.6.10
-* Upgrade CompileSdkVersion and targetSdkVersion to 32
+* Upgrade `compileSdkVersion` and `targetSdkVersion` to 32
 * Upgrade DataDome SDK Core versions
 
 ## 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.0
 
 * Migrate to Android V2
-* Upgrade Flutter SDK version for versions < 4.0.0
+* Upgrade Dart SDK version to be compatible with Dart 3
 * Upgrade Kotlin version to 1.6.10
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to 32
 * Upgrade DataDome SDK Core versions

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
This version includes:
* Migrate to Android V2
* upgrade Dart SDK version `sdk: '>=2.12.0 <4.0.0'` to be compatible to Dart 3
* Upgrade kotlin version to 1.6.10
* Upgrade CompileSdkVersion and targetSdkVersion to 32
* Upgrade DataDome SDK Core versions: 
    -  Change Android native SDK dependency from jitpack to maven
    - Import Android native SDK 1.8.0
    - Upgrade iOS SDK version to 3.2.2 (with pod upgrade DataDomeSDK)
 Those versions embed several improvements including Event Tracking throttling
* Upgrade gradle to version 7.1.2
* Upgrade okhttp library to 4.9.0 
* Define android:exported value in AndroidManifest.xml file
* Replace internal testing url and client key by a static text ('test_url')