### PR TITLE
upgrade native SDKs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'co.datadome.sdk:sdk:1.8.0'
+    implementation 'co.datadome.sdk:sdk:1.14.0'
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - datadome (1.0.0):
     - DataDomeSDK
     - Flutter
-  - DataDomeSDK (3.2.2)
+  - DataDomeSDK (3.6.0)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -21,9 +21,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   datadome: cfb156bd2b99a6e571eb2e7ccb6b89416b47f50a
-  DataDomeSDK: c9c2a1f6f1b1aad30ec4f43867f07c558d76e0bf
+  DataDomeSDK: a3c3924d00cac8c3c1d7afd18a213263a739cf0e
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.15.2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the datadome plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.3

--- a/lib/datadome.dart
+++ b/lib/datadome.dart
@@ -97,7 +97,6 @@ class DataDome {
       Map<String, String> headers,
       body,
       ) async {
-
     final args = {
       'csk': this.key,
       'method': describeEnum(method),
@@ -106,15 +105,20 @@ class DataDome {
       'body': body
     };
 
-    final Map<dynamic, dynamic>? response = await (_channel.invokeMapMethod('request', args) as FutureOr<Map<dynamic, dynamic>?>);
-    Map<String, String> responseHeaders = new Map<String, String>.from(response?['headers']);
-    http.Response httpResponse = http.Response.bytes(
-        response?['data'],
-        response?['code'],
-        headers: responseHeaders
-    );
+    final Map<dynamic, dynamic>? response = await (_channel.invokeMapMethod('request', args));
+    try {
+      Map<String, String> responseHeaders = new Map<String, String>.from(
+          response?['headers']);
+      http.Response httpResponse = http.Response.bytes(
+          response?['data'],
+          response?['code'],
+          headers: responseHeaders
+      );
 
-    return httpResponse;
+      return httpResponse;
+    } catch(_) {
+      throw 'Unexpected HTTP response format';
+    }
   }
 }
 

--- a/lib/datadome.dart
+++ b/lib/datadome.dart
@@ -106,11 +106,11 @@ class DataDome {
       'body': body
     };
 
-    final Map<dynamic, dynamic> response = await (_channel.invokeMapMethod('request', args) as FutureOr<Map<dynamic, dynamic>>);
-    Map<String, String> responseHeaders = new Map<String, String>.from(response['headers']);
+    final Map<dynamic, dynamic>? response = await (_channel.invokeMapMethod('request', args) as FutureOr<Map<dynamic, dynamic>?>);
+    Map<String, String> responseHeaders = new Map<String, String>.from(response?['headers']);
     http.Response httpResponse = http.Response.bytes(
-        response['data'],
-        response['code'],
+        response?['data'],
+        response?['code'],
         headers: responseHeaders
     );
 


### PR DESCRIPTION
- Upgrade Android SDK from 1.8.0 to 1.14.0
- Upgrade iOS SDK from 3.2.2 to 3.6.0

Those new versions includes:
- Add support for HTML challenges
- Add support for additional challenges following an invisible Device Check
- Add `DataDomeWebView` class for automated cookie sharing in Android
- Fix a rare crash triggered by the gesture capture module for iOS
- Fix the animation for invisible device-check dismiss in Android