### PR TITLE
chore(int-5871): Upgrade Android SDK version to v3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'co.datadome.sdk:sdk:1.14.0'
+    implementation 'co.datadome.sdk:sdk:3.+'
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.0'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Jira ticket: INT-5871- [Flutter HTTP] Update Android dependency to our native SDK
```markdown
## Description
Update the Android SDK version to v3+
This new SDK plugin version will compatible with the new Android releases

## Summary of changes

- Update the Android SDK version from 1.14.0 to v3+
- Upgrade the Kotlin version to 1.9.10: This version is the minimum required version since v1.14.5

No changes were required on the sample app as the plugin implements `http` methods

## How to review this PR?

The change was tested in Android with json and HTML response

## How to test?

Launch the app with different scenarios and make sure that nothing was broken

```