### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (2025-11-06)
+
+* Upgrade `http` dependecy version to `^1.0.0`
+* Update the major supported version of DataDome iOS SDK 
+* Upgrade DataDome Android SDK version
+
 ## 1.2.0
 
 * Add support for HTML challenges 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 2.0.0 (2025-11-06)
 
 * Upgrade `http` dependency version to `^1.0.0`
-* Upgrade DataDome Android SDK dependency to fetch the latest `3.x.x` released version
+* Upgrade DataDome Android SDK dependency to `^3.0.0`
+
+### Android requirements
+* Minimum API level (`minSdkVersion`): 19
+* Minimum Kotlin version: 1.9.0
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0 (2025-11-06)
 
-* Upgrade `http` dependecy version to `^1.0.0`
+* Upgrade `http` dependency version to `^1.0.0`
 * Update the major supported version of DataDome iOS SDK 
 * Upgrade DataDome Android SDK version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 2.0.0 (2025-11-06)
 
 * Upgrade `http` dependency version to `^1.0.0`
-* Update the major supported version of DataDome iOS SDK 
-* Upgrade DataDome Android SDK version
+* Upgrade DataDome Android SDK dependency to fetch the latest `3.x.x` released version
 
 ## 1.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadome
 description: DataDome Flutter Plugin that integrates DataDome protection into Flutter apps, adapting the iOS and Android SDKs to secure your app's networking layer.
-version: 2.0.0-beta.0
+version: 2.0.0
 homepage: https://datadome.co
 documentation: https://docs.datadome.co/docs/flutter-plugin
 


### PR DESCRIPTION
Jira ticket: [INT-5887](https://datadome.atlassian.net/browse/INT-5887)

## Description

Release flutter plugin SDK v2.0.0. This version 
- upgrades the `http` dependency version to `^1.0.0`
- upgrade the native android SDK dependency to v "^3.0.0"
- internal improvements on the podspec file

### Pull-Requests
- https://github.com/DataDome/datadome-flutter/pull/26
- https://github.com/DataDome/datadome-flutter/pull/25
- https://github.com/DataDome/datadome-flutter/pull/24

### Vulnerability fixes
Limits the fetch of the major supported version of the iOS native SDK to the ^3.0.0 (excludes eventual v4 fetch)

**Requirements in Android**
Minimum API level (minSdkVersion): 19
Minimum Kotlin version: 1.9.0

[INT-5887]: https://datadome.atlassian.net/browse/INT-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ