### PR TITLE
update deploy pipeline with changelog scripts

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,7 +34,7 @@ pipelines:
           - publish_to_pub_dev
       create-rss-changelog:
         depends_on:
-          - publish_to_pub_dev
+          - publish_to_pub_dev  
 workflows:
   init:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,6 +29,12 @@ pipelines:
       publish_to_pub_dev:
         depends_on:
         - init
+      publish-changelog:
+        depends_on:
+          - publish_to_pub_dev
+      create-rss-changelog:
+        depends_on:
+          - publish_to_pub_dev
 workflows:
   init:
     steps:
@@ -74,3 +80,36 @@ workflows:
         title: Publish to pub.dev
         inputs:
         - content: dart pub publish
+  create-rss-changelog:
+    steps:
+    - pull-intermediate-files@1:
+        inputs:
+        - artifact_sources: init
+    - set-env-var@0:
+        inputs:
+        - value: CHANGELOG.md
+        - destination_keys: DOCUMENTATION_FILE_PATH
+    - script-runner@0:
+        title: Create changelog entry
+        inputs:
+        - file_path: $BITRISE_SOURCE_DIR/scripts/post_changelog_to_public_documentation_rss_feed.sh
+        - runner: bash
+  publish-changelog:
+    steps:
+    - pull-intermediate-files@1:
+        inputs:
+        - artifact_sources: init
+    - set-env-var@0:
+        inputs:
+        - value: CHANGELOG.md
+        - destination_keys: DOCUMENTATION_FILE_PATH
+    - script-runner@0:
+        title: Update the documentation
+        inputs:
+        - file_path: $BITRISE_SOURCE_DIR/scripts/update_public_documentation_page.sh
+        - runner: bash
+app:
+  envs:
+  - PUBLIC_CHANGELOG_PAGE_SLUG: flutter-plugin-changelog
+    opts:
+      is_expand: false

--- a/scripts/post_changelog_to_public_documentation_rss_feed.sh
+++ b/scripts/post_changelog_to_public_documentation_rss_feed.sh
@@ -7,8 +7,8 @@ set -e
 set -x
 
 # privacy_view options:
-README_HIDE_PUBLICATION="anyone_with_link"
-README_PUBLIC_PUBLICATION="public"
+README_RSS_ENTRY_VISIBILITY_PRIVATE="anyone_with_link"
+README_RSS_ENTRY_VISIBILITY_PUBLIC ="public"
 
 # Extract the CHANGELOG section corresponding to the specified TAG
 POST_BODY=$(awk '/## '${BITRISE_GIT_TAG}'/{flag=1;next}/^## /{flag=0}flag' $DOCUMENTATION_FILE_PATH)

--- a/scripts/post_changelog_to_public_documentation_rss_feed.sh
+++ b/scripts/post_changelog_to_public_documentation_rss_feed.sh
@@ -13,7 +13,7 @@ README_RSS_ENTRY_VISIBILITY_PUBLIC ="public"
 # Extract the CHANGELOG section corresponding to the specified TAG
 POST_BODY=$(awk '/## '${BITRISE_GIT_TAG}'/{flag=1;next}/^## /{flag=0}flag' $DOCUMENTATION_FILE_PATH)
 
-jq -n --arg body "${POST_BODY}" --arg title "Flutter HTTP SDK ${BITRISE_GIT_TAG}" --arg privacy_view "${README_PUBLIC_PUBLICATION}" \
+jq -n --arg body "${POST_BODY}" --arg title "Flutter HTTP SDK ${BITRISE_GIT_TAG}" --arg privacy_view "${README_RSS_ENTRY_VISIBILITY_PUBLIC}" \
     '{title: $title, content: {body: $body}, privacy: {view: $privacy_view}}' > changelog_rss_release.json
 
 # BITRISE_README_TOKEN is the readme.com token, stored in the Bitrise secret manager

--- a/scripts/post_changelog_to_public_documentation_rss_feed.sh
+++ b/scripts/post_changelog_to_public_documentation_rss_feed.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# fail if any commands fails
+set -e
+
+# debug log
+set -x
+
+POST=$(awk '/## '${BITRISE_GIT_TAG}'/{flag=1;next}/^## /{flag=0}flag' $DOCUMENTATION_FILE_PATH)
+POST_BODY=$(sed 's/$/\\n/' <<<"$POST" | tr -d '\n')
+
+# BITRISE_README_TOKEN is the readme.com token, stored in the Bitrise secret manager
+curl --request POST \
+     --url https://dash.readme.com/api/v1/changelogs \
+     --header "authorization: Basic ${BITRISE_README_TOKEN}" \
+     --header 'content-type: application/json' \
+     --data '
+{
+  "hidden": true,
+  "title": "'"Flutter HTTP SDK ${BITRISE_GIT_TAG}"'",
+  "body": "'"$POST_BODY"'"
+}
+'

--- a/scripts/update_public_documentation_page.sh
+++ b/scripts/update_public_documentation_page.sh
@@ -13,7 +13,7 @@ README_DEFAULT_BRANCH_NAME="stable"
 
 FILE_BODY=$(cat $DOCUMENTATION_FILE_PATH)
 
-jq -n --arg body "${FILE_BODY}" --arg privacy_view "${README_PUBLIC_PUBLICATION}" \
+jq -n --arg body "${FILE_BODY}" --arg privacy_view "${README_PAGE_VISIBILITY_PUBLIC}" \
     '{content: {body: $body}, privacy: {view: $privacy_view}}' > changelog.json
 
 curl --request PATCH \

--- a/scripts/update_public_documentation_page.sh
+++ b/scripts/update_public_documentation_page.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# fail if any commands fails
+set -e
+
+# debug log
+set -x
+
+FILE_BODY=$(sed 's/$/\\n/' $DOCUMENTATION_FILE_PATH | tr -d '\n')
+
+curl --request PUT \
+     --url https://docs.datadome.co/docs/$PUBLIC_CHANGELOG_PAGE_SLUG \
+     --header 'accept: application/json' \
+     --header "authorization: Basic ${BITRISE_README_TOKEN}" \
+     --header 'content-type: application/json' \
+     --data '
+    {
+  "body": "'"$FILE_BODY"'"
+  }
+  '

--- a/scripts/update_public_documentation_page.sh
+++ b/scripts/update_public_documentation_page.sh
@@ -7,8 +7,8 @@ set -e
 set -x
 
 # privacy_view options:
-README_HIDE_PUBLICATION="anyone_with_link"
-README_PUBLIC_PUBLICATION="public"
+README_PAGE_VISIBILITY_PRIVATE="anyone_with_link"
+README_PAGE_VISIBILITY_PUBLIC ="public"
 README_DEFAULT_BRANCH_NAME="stable"
 
 FILE_BODY=$(cat $DOCUMENTATION_FILE_PATH)


### PR DESCRIPTION
Jira ticket: [INT-6002](https://datadome.atlassian.net/browse/INT-6002)
## Description

Automate the Readme changelog and rss documentation update with new release changes.

## Summary of changes

- Update the release pipeline with `publish-changelog` and `create-rss-changelog` workflows
- `publish-changelog`: publish a copy of the local repository changelog
- `create-rss-changelog`: parse the last release changes between the `## {TAG} -> ##` text and publish it to rss changelog

## How to review this PR?

- The full changelog update flow will be tested in the upcoming Flutter HTTP SDK release
- The PR was tested with a push trigger on Bitrise

## How to test?

- During the upcoming Flutter HTTP SDK release:
   -  check if the changelog workflows were triggered after the deploy to pub_dev
   - check if the Readme changelog and rss were updated with the last release TAG and changes
   - make the rss publication public: by default this was set to hidden for safety


[INT-6002]: https://datadome.atlassian.net/browse/INT-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ