### PR TITLE
bypass confirmation and add check package safety

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -71,6 +71,10 @@ workflows:
         inputs:
         - artifact_sources: init
     - script@1:
+      title: Validating package safety
+      inputs:
+      - content: dart pub publish --dry-run
+    - script@1:
         title: Publish to pub.dev
         inputs:
-        - content: dart pub publish
+        - content: dart pub publish --force


### PR DESCRIPTION
Jira ticket: [INT-6028](https://datadome.atlassian.net/browse/INT-6028)
## Description

Bypass the manual confirmation at the package publication on pub.dev with Bitrise.
This step was blocking the `publish_to_pub_dev` workflow on Bitrise, hence, blocking the package from being automatically deployed.

## Summary of changes

- Forcing the `dart pub publish` command with `--force`
- Add the package safety validation step with `--dry-run`

## How to review this PR?


## How to test?

This change will be validated at the next Flutter HTTP SDK release with the next release tag push

## References

- Here is the options documentation: https://dart.dev/tools/pub/cmd/pub-lish#options
- The Validating package safety step (with `--dry-run`) is optional/ recommended **as the `--force` ignores the package warnings**
- The --skip-validation option does not skip the publication confirmation but skips the package validation (dependency check, pubspec.yaml format...)


[INT-6028]: https://datadome.atlassian.net/browse/INT-6028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ